### PR TITLE
Display events and add join form

### DIFF
--- a/templates/main/admin.html
+++ b/templates/main/admin.html
@@ -34,23 +34,32 @@
     <!-- Past Events -->
     <div class="glass-card" data-aos="fade-right">
       <h2 class="text">Past Events</h2>
-      <ul>
-        <li><strong>Tech Connect 2024</strong> April 20, 2024
-          <button onclick="alert('Viewing insights for Tech Connect 2024')">View Insights</button>
-        </li>
-        <li><strong>Innovation Summit</strong> March 10, 2024
-          <button onclick="alert('Viewing insights for Innovation Summit')">View Insights</button>
-        </li>
-      </ul>
+      {% if past_events %}
+        <ul>
+          {% for event in past_events %}
+            <li>
+              <strong>{{ event.name }}</strong> {{ event.date }}
+              <button onclick="alert('Viewing insights for {{ event.name }}')">View Insights</button>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>No past events.</p>
+      {% endif %}
     </div>
 
     <!-- Upcoming Events -->
     <div class="glass-card" data-aos="fade-left">
       <h2>Upcoming Events</h2>
-      <ul>
-        <li><strong>FutureX Fair</strong> July 15, 2025 <em>[Draft]</em></li>
-        <li><strong>AI Expo</strong> August 3, 2025 <em>[Published]</em></li>
-      </ul>
+      {% if upcoming_events %}
+        <ul>
+          {% for event in upcoming_events %}
+            <li><strong>{{ event.name }}</strong> {{ event.date }}</li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>No upcoming events.</p>
+      {% endif %}
     </div>
 
     <!-- New Event Form (Initially Hidden) -->

--- a/templates/main/attendee.html
+++ b/templates/main/attendee.html
@@ -30,6 +30,16 @@
       </ul>
     {% endif %}
 
+    <!-- Join Event Form -->
+    <div class="glass-card" data-aos="zoom-in-up">
+      <h2>Join an Event</h2>
+      <form method="post" action="{% url 'join_event' %}">
+        {% csrf_token %}
+        <input type="text" class="form-input large" name="event_code" placeholder="Enter Event Code" required />
+        <button class="glow-button" type="submit">Join Event</button>
+      </form>
+    </div>
+
     <!-- Register Form -->
     <div id="register-form" class="glass-card" style="display:none;" data-aos="zoom-in-up">
       <h2> Register for an Event</h2>

--- a/templates/main/employee.html
+++ b/templates/main/employee.html
@@ -39,20 +39,36 @@
       </form>
     </div>
 
-    <!-- Joined Events List -->
+    <!-- Upcoming Events -->
     <div class="glass-card" data-aos="fade-up">
-      <h2>Your Events</h2>
-      {% if joined_events %}
+      <h2>Upcoming Events</h2>
+      {% if upcoming_events %}
         <ul>
-          {% for event in joined_events %}
+          {% for event in upcoming_events %}
             <li>
               <strong>{{ event.name }}</strong> - {{ event.date }} at {{ event.location }}
-              <a class="see-more" href="{% url 'scanner_page' event.id %}">Open Scanner</a>
+              <a class="see-more" href="{% url 'scanner_view' %}">Open Scanner</a>
             </li>
           {% endfor %}
         </ul>
       {% else %}
-        <p>You haven't joined any events yet.</p>
+        <p>No upcoming events.</p>
+      {% endif %}
+    </div>
+
+    <!-- Past Events -->
+    <div class="glass-card" data-aos="fade-up">
+      <h2>Past Events</h2>
+      {% if past_events %}
+        <ul>
+          {% for event in past_events %}
+            <li>
+              <strong>{{ event.name }}</strong> - {{ event.date }} at {{ event.location }}
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>No past events.</p>
       {% endif %}
     </div>
   </section>


### PR DESCRIPTION
## Summary
- categorize events for admin and employee dashboards
- list upcoming and past events in admin and employee templates
- allow employees to join events with form data
- add join event form for attendees

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6846f9d372d883219470da755b1ab04a