### PR TITLE
Add profile picture upload for attendees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 
 # Personal or sensitive files
 *.env
+media/

--- a/.whatidid
+++ b/.whatidid
@@ -9,3 +9,4 @@
 - add join event form for attendees
 - show attendee's upcoming and past events
 - ensure attendee views require login
+- add attendee profile page with picture upload

--- a/core/settings.py
+++ b/core/settings.py
@@ -31,6 +31,10 @@ ALLOWED_HOSTS = []
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / "static"]
 
+# Media files uploaded by users
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,3 +30,6 @@ urlpatterns = [
     # / is the root of the url all the urls will look like /dashboard like nomral routing
     path('', include('mainapp.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('employee-panel/', views.employee, name='employee'),
 
     path('dashboard/', views.attendee_dashboard, name='attendee_dashboard'),
+    path('profile/', views.attendee_profile, name='attendee_profile'),
     path('create-event/', views.create_event, name='create_event'),
     path('api/events/', views.get_events_json, name='get_events_json'),
     # path('employee/join_event/', views.join_event_as_employee, name='join_event_as_employee'),

--- a/templates/main/attendee.html
+++ b/templates/main/attendee.html
@@ -13,6 +13,7 @@
       {% if user.is_authenticated %}
         <a href="{% url 'logout' %}">Logout</a>
       {% endif %}
+      <a href="{% url 'attendee_profile' %}">Profile</a>
       <a href="#" onclick="toggleRegisterForm()">Register for Event</a>
     </nav>
   </header>

--- a/templates/main/profile.html
+++ b/templates/main/profile.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Your Profile{% endblock %}
+{% load static %}
+{% block content %}
+<header class="navbar">
+  <div class="logo">EasyConnect Attendee</div>
+  <nav class="nav-links">
+    <a href="{% url 'attendee_dashboard' %}">Dashboard</a>
+    <a href="{% url 'logout' %}">Logout</a>
+  </nav>
+</header>
+<section class="hero">
+  <h1 class="hero-title">Your Profile</h1>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    <div class="glass-card" data-aos="fade-up">
+      {% if profile.profile_picture %}
+        <img src="{{ profile.profile_picture.url }}" alt="Profile picture" style="max-width:150px;display:block;margin-bottom:1rem;" />
+      {% endif %}
+      <input type="file" name="profile_picture" class="form-input large" />
+      <input type="text" class="form-input large" name="full_name" value="{{ request.user.full_name }}" placeholder="Full Name" required />
+      <input type="email" class="form-input large" value="{{ request.user.email }}" readonly />
+      <textarea class="form-input large" name="bio" placeholder="Bio">{{ profile.bio }}</textarea>
+      <input type="url" class="form-input large" name="linkedin" value="{{ profile.linkedin }}" placeholder="LinkedIn URL" />
+      <input type="url" class="form-input large" name="website" value="{{ profile.website }}" placeholder="Website URL" />
+      <button type="submit" class="glow-button">Save Changes</button>
+    </div>
+  </form>
+</section>
+<script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+<script>AOS.init();</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow attendees to upload and view a profile picture
- serve uploaded media in development

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6847179f541483218f4db2e09d790c36